### PR TITLE
Added opponent board.

### DIFF
--- a/Battleship/BattleshipGame.cs
+++ b/Battleship/BattleshipGame.cs
@@ -18,10 +18,28 @@ namespace Battleship
         private SpriteBatch _spriteBatch;
 
         /// <summary>
-        /// Internal grid object.
-        /// One for each player.
+        /// The grid size
+        /// </summary>
+        private const int _GRIDSIZE = 11;
+
+        ///<summary>
+        /// Player 1 grid offset value.
+        /// </summary>
+        private const int _PLAYER1OFFSET = 0;
+
+        ///<summary>
+        /// Player 2 grid offset value.
+        /// </summary>
+        private const int _PLAYER2OFFSET = 500;
+
+        /// <summary>
+        /// Player 1 grid object.
         /// </summary>
         private Grid _player1grid;
+
+        /// <summary>
+        /// Player 2 grid object.
+        /// </summary>
         private Grid _player2grid;
 
         /// <summary>
@@ -47,8 +65,8 @@ namespace Battleship
 
             Window.Title = "Battleship";
 
-            _player1grid = new Grid(11);
-            _player2grid = new Grid(11);
+            _player1grid = new Grid(_GRIDSIZE, _PLAYER1OFFSET);
+            _player2grid = new Grid(_GRIDSIZE, _PLAYER2OFFSET);
 
             base.Initialize();
         }
@@ -79,32 +97,6 @@ namespace Battleship
 
             base.Update(gameTime);
         }
-        /// <summary>
-        /// Helper method to handle mouse interaction with a grid using the grid's position offset.
-        /// </summary>
-        /// <param name="_grid">A grid object.</param>
-        private void HandleGridInteraction(Grid _grid, Vector2 _position)
-        {
-            // Get which square the mouse is inside of
-            MouseState mouseState = Mouse.GetState();
-            Point moustPoint = new Point(mouseState.X - (int)_position.X, mouseState.Y - (int)_position.Y); // Offset the mouse position by the grid's position
-            foreach (GridTile tile in _grid.GridArray)
-            {
-                if (tile.GridRectangle.Contains(moustPoint) && tile.CanSelect)
-                {
-                    tile.MouseOver = true;
-
-                    if (mouseState.LeftButton == ButtonState.Pressed && !tile.IsMiss && !tile.IsHit)
-                        tile.IsMiss = true;
-                    if (mouseState.RightButton == ButtonState.Pressed && !tile.IsMiss && !tile.IsHit)
-                        tile.IsHit = true;
-                }
-                else if (!tile.GridRectangle.Contains(moustPoint) && tile.MouseOver)
-                {
-                    tile.MouseOver = false;
-                }
-            }
-        }
 
         /// <summary>
         /// Draws objects to the screen. Called constantly in a loop.
@@ -120,30 +112,6 @@ namespace Battleship
             _spriteBatch.End();
 
             base.Draw(gameTime);
-        }
-        /// <summary>
-        ///  Helper method to draw a grid at a specified position.
-        /// </summary>
-        /// <param name="_grid"></param>
-        /// <param name="postition"></param>
-        private void DrawGrid(Grid _grid, Vector2 postition)
-        {
-            GridTile[,] gridArray = _grid.GridArray;
-            foreach (GridTile tile in gridArray)
-            {
-                Texture2D texture;
-                if (tile.IsMiss)
-                    texture = _grid.SquareMissedTexture;
-                else if (tile.IsHit)
-                    texture = _grid.SquareHitTexture;
-                else if (tile.MouseOver)
-                    texture = _grid.SquareSelectedTexture;
-                else
-                    texture = tile.GridTexture;
-
-                // Draw each tile, offset by the grid's position
-                _spriteBatch.Draw(texture, new Rectangle(tile.GridRectangle.X + (int)postition.X, tile.GridRectangle.Y + (int)postition.Y, tile.GridRectangle.Width, tile.GridRectangle.Height), Color.White);
-            }
         }
     }
 }

--- a/Battleship/BattleshipGame.cs
+++ b/Battleship/BattleshipGame.cs
@@ -18,11 +18,15 @@ namespace Battleship
         private SpriteBatch _spriteBatch;
 
         /// <summary>
-        /// Two internal grid objects. One for player and one for opponent.
+        /// Internal grid object.
+        /// One for each player.
         /// </summary>
-        private Grid _playerGrid;
-        private Grid _opponentGrid;
+        private Grid _player1grid;
+        private Grid _player2grid;
 
+        /// <summary>
+        /// Constructor for the Battleship game.
+        /// </summary>
         public BattleshipGame()
         {
             _graphics = new GraphicsDeviceManager(this);
@@ -43,8 +47,8 @@ namespace Battleship
 
             Window.Title = "Battleship";
 
-            _playerGrid = new Grid(11);
-            _opponentGrid = new Grid(11);
+            _player1grid = new Grid(11);
+            _player2grid = new Grid(11);
 
             base.Initialize();
         }
@@ -57,39 +61,8 @@ namespace Battleship
         {
             _spriteBatch = new SpriteBatch(GraphicsDevice);
 
-            // Load the player grid textures
-            LoadGridTextures(_playerGrid, "player");
-            LoadGridTextures(_opponentGrid, "opponent");
-        }
-
-        /// <summary>
-        /// Helper method to load textures for a specific grid.
-        /// </summary>
-        /// <param name="grid">A grid object.</param>
-        /// <param name="gridOwner">The player the grid belongs to.</param>
-        private void LoadGridTextures(Grid _grid, string _gridOwner)
-        {
-            GridTile[,] gridArray = _grid.GridArray;
-            gridArray[0, 0].GridTexture = Content.Load<Texture2D>("top_corner");
-
-            for (int tileNum = 1; tileNum < _grid.Size; tileNum++)
-            {
-                gridArray[0, tileNum].GridTexture = Content.Load<Texture2D>($"column_{tileNum}");
-                gridArray[tileNum, 0].GridTexture = Content.Load<Texture2D>($"row_{tileNum}");
-            }
-
-            for (int colNum = 1; colNum < _grid.Size; colNum++)
-            {
-                for (int rowNum = 1; rowNum < _grid.Size; rowNum++)
-                {
-                    gridArray[colNum, rowNum].GridTexture = Content.Load<Texture2D>("square");
-                    gridArray[colNum, rowNum].CanSelect = true;
-                }
-            }
-
-            _grid.SquareSelectedTexture = Content.Load<Texture2D>("square_selected");
-            _grid.SquareMissedTexture = Content.Load<Texture2D>("square_miss");
-            _grid.SquareHitTexture = Content.Load<Texture2D>("square_hit");
+            _player1grid.LoadContent(Content);
+            _player2grid.LoadContent(Content);
         }
 
         /// <summary>
@@ -101,11 +74,8 @@ namespace Battleship
             if (GamePad.GetState(PlayerIndex.One).Buttons.Back == ButtonState.Pressed || Keyboard.GetState().IsKeyDown(Keys.Escape))
                 Exit();
 
-            // Handle mouse interaction of player grid
-            HandleGridInteraction(_playerGrid, new Vector2(0,0));
-
-            // Handle mouse interaction with opponent grid
-            HandleGridInteraction(_opponentGrid, new Vector2(500,0));
+            _player1grid.Update();
+            _player2grid.Update();
 
             base.Update(gameTime);
         }
@@ -145,11 +115,8 @@ namespace Battleship
             GraphicsDevice.Clear(Color.CornflowerBlue);
 
             _spriteBatch.Begin(samplerState: SamplerState.PointClamp);
-
-            // Draw the player grid starting at (50,50) and the opponent grid starting at (550,50)
-            DrawGrid(_playerGrid, new Vector2(0, 0));
-            DrawGrid(_opponentGrid, new Vector2(500, 0));
-
+            _player1grid.Draw(_spriteBatch);
+            _player2grid.Draw(_spriteBatch);
             _spriteBatch.End();
 
             base.Draw(gameTime);

--- a/Battleship/Grid.cs
+++ b/Battleship/Grid.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Battleship
@@ -45,11 +46,41 @@ namespace Battleship
         /// </summary>
         public int Size { get; set; }
 
+        ///<summary>
+        ///The number associated with the grid's player.
+        ///i.e. 1 for player 1, 2 for player 2.
+        /// </summary>
+        public int playerNum { get; set; }
+
+        ///<summary>
+        /// Static property to keep track of the current player.
+        /// Increments by 1 each time a new player is created.
+        /// </summary>
+        private static int _playerCounter = 0;
+
+        /// <summary>
+        /// The 
+        /// </summary>
+        private Vector2 _position;
+
+        /// <summary>
+        /// The previous mouse point from the last update cycle.
+        /// </summary>
+        private Point _previousMousePoint;
+
+        /// <summary>
+        /// Whether or not the mouse has updated.
+        /// </summary>
+        private bool _mouseUpdated;
+
         public Grid(int size)
         {
-            // Initialize the 2D Array
+            // Initialize the 2D Array. 
             GridArray = new GridTile[size, size];
             Size = size;
+            this.playerNum = Interlocked.Increment(ref _playerCounter); // Increment the player counter and assign the value to playerNum. Thread-safe.
+            this._position = this.playerNum == 1 ? new Vector2(0, 0) : new Vector2(500, 0); // Set the position of the grid based on the player number.
+
 
             // Initialize each GridTile
             for (int rowNum = 0; rowNum < size; rowNum++)
@@ -61,6 +92,95 @@ namespace Battleship
 
                     GridArray[rowNum, colNum] = new GridTile(squarePosition, squareSize);
                 }
+            }
+        }
+
+        /// <summary>
+        /// LoadContent for the grid.
+        /// </summary>
+        public void LoadContent(ContentManager content)
+        {
+            GridArray[0, 0].GridTexture = content.Load<Texture2D>("top_corner");
+
+            for (int tileNum = 1; tileNum < Size; tileNum++)
+            {
+                GridArray[0, tileNum].GridTexture = content.Load<Texture2D>($"column_{tileNum}");
+                GridArray[tileNum, 0].GridTexture = content.Load<Texture2D>($"row_{tileNum}");
+            }
+
+            for (int colNum = 1; colNum < Size; colNum++)
+            {
+                for (int rowNum = 1; rowNum < Size; rowNum++)
+                {
+                    GridArray[colNum, rowNum].GridTexture = content.Load<Texture2D>("square");
+                    GridArray[colNum, rowNum].CanSelect = true;
+                }
+            }
+
+            SquareSelectedTexture = content.Load<Texture2D>("square_selected");
+            SquareMissedTexture = content.Load<Texture2D>("square_miss");
+            SquareHitTexture = content.Load<Texture2D>("square_hit");
+        }
+
+        /// <summary>
+        /// Update for the grid.
+        /// </summary>
+        public void Update()
+        {
+            MouseState mouseState = Mouse.GetState();
+            Point mousePoint = new Point(mouseState.X - (int)_position.X, mouseState.Y - (int)_position.Y); // Offset the mouse position by the grid's position 
+            
+            // Skip update loop if the mouse has not moved
+            if (mousePoint.X == _previousMousePoint.X && mousePoint.Y == _previousMousePoint.Y)
+            {
+                _mouseUpdated = false;
+                return;
+            }
+            else
+            {
+                _mouseUpdated = true;
+            }
+
+            // Get which square the mouse is inside of
+            foreach (GridTile tile in GridArray)
+            {
+                if (tile.GridRectangle.Contains(mousePoint) && tile.CanSelect)
+                {
+                    tile.MouseOver = true;
+
+                    if (mouseState.LeftButton == ButtonState.Pressed && !tile.IsMiss && !tile.IsHit)
+                        tile.IsMiss = true;
+                    if (mouseState.RightButton == ButtonState.Pressed && !tile.IsMiss && !tile.IsHit)
+                        tile.IsHit = true;
+                }
+                else if (!tile.GridRectangle.Contains(mousePoint) && tile.MouseOver)
+                {
+                    tile.MouseOver = false;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Draw for the grid.
+        /// </summary>
+        public void Draw(SpriteBatch spriteBatch)
+        {
+            if (!_mouseUpdated)
+                return;
+
+            foreach (GridTile tile in GridArray)
+            {
+                Texture2D texture;
+                if (tile.IsMiss)
+                    texture = SquareMissedTexture;
+                else if (tile.IsHit)
+                    texture = SquareHitTexture;
+                else if (tile.MouseOver)
+                    texture = SquareSelectedTexture;
+                else
+                    texture = tile.GridTexture;
+
+                spriteBatch.Draw(texture, new Rectangle(tile.GridRectangle.X +(int)_position.X, tile.GridRectangle.Y + (int)_position.Y, tile.GridRectangle.Width, tile.GridRectangle.Height), Color.White);
             }
         }
     }

--- a/Battleship/Grid.cs
+++ b/Battleship/Grid.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,12 +16,12 @@ namespace Battleship
         /// <summary>
         /// The number of pixels for the width and height of each square.
         /// </summary>
-        private const int _squareSize = 9;
+        private const int _SQUARESIZE = 9;
 
         /// <summary>
         /// The scale factor between the texture and actual display.
         /// </summary>
-        private const int _scale = 5;
+        private const int _SCALE = 5;
 
         /// <summary>
         /// The 2D Array representing and storing the grid.
@@ -46,22 +48,10 @@ namespace Battleship
         /// </summary>
         public int Size { get; set; }
 
-        ///<summary>
-        ///The number associated with the grid's player.
-        ///i.e. 1 for player 1, 2 for player 2.
-        /// </summary>
-        public int playerNum { get; set; }
-
-        ///<summary>
-        /// Static property to keep track of the current player.
-        /// Increments by 1 each time a new player is created.
-        /// </summary>
-        private static int _playerCounter = 0;
-
         /// <summary>
-        /// The 
+        /// The horizontal offset value used for drawing the grid.
         /// </summary>
-        private Vector2 _position;
+        private int _offset { get; set; }
 
         /// <summary>
         /// The previous mouse point from the last update cycle.
@@ -73,13 +63,12 @@ namespace Battleship
         /// </summary>
         private bool _mouseUpdated;
 
-        public Grid(int size)
+        public Grid(int size, int offset)
         {
             // Initialize the 2D Array. 
             GridArray = new GridTile[size, size];
             Size = size;
-            this.playerNum = Interlocked.Increment(ref _playerCounter); // Increment the player counter and assign the value to playerNum. Thread-safe.
-            this._position = this.playerNum == 1 ? new Vector2(0, 0) : new Vector2(500, 0); // Set the position of the grid based on the player number.
+            _offset = offset;
 
 
             // Initialize each GridTile
@@ -87,8 +76,8 @@ namespace Battleship
             {
                 for (int colNum = 0; colNum < size; colNum++)
                 {
-                    Point squarePosition = new Point(colNum * _squareSize * _scale, rowNum * _squareSize * _scale);
-                    Point squareSize = new Point(_squareSize * _scale, _squareSize * _scale);
+                    Point squarePosition = new (colNum * _SQUARESIZE * _SCALE + _offset, rowNum * _SQUARESIZE * _SCALE);
+                    Point squareSize = new (_SQUARESIZE * _SCALE, _SQUARESIZE * _SCALE);
 
                     GridArray[rowNum, colNum] = new GridTile(squarePosition, squareSize);
                 }
@@ -128,7 +117,7 @@ namespace Battleship
         public void Update()
         {
             MouseState mouseState = Mouse.GetState();
-            Point mousePoint = new Point(mouseState.X - (int)_position.X, mouseState.Y - (int)_position.Y); // Offset the mouse position by the grid's position 
+            Point mousePoint = new (mouseState.X, mouseState.Y);
             
             // Skip update loop if the mouse has not moved
             if (mousePoint.X == _previousMousePoint.X && mousePoint.Y == _previousMousePoint.Y)
@@ -180,7 +169,7 @@ namespace Battleship
                 else
                     texture = tile.GridTexture;
 
-                spriteBatch.Draw(texture, new Rectangle(tile.GridRectangle.X +(int)_position.X, tile.GridRectangle.Y + (int)_position.Y, tile.GridRectangle.Width, tile.GridRectangle.Height), Color.White);
+                spriteBatch.Draw(texture, new Rectangle(tile.GridRectangle.X, tile.GridRectangle.Y, tile.GridRectangle.Width, tile.GridRectangle.Height), Color.White);
             }
         }
     }


### PR DESCRIPTION
Major changes:

- Increased window width to 1000 to fit both windows
- Created helper functions from pre-existing logic to reduce redundant logic in executing identical logic for each grid object
- Tweaked mouse handling and draw logic to account for two boards.

Embedded video demos game behavior. Hovering behavior is distinct for both grids, left- and right-clicking perform miss and hit behaviors, respectively (not the final behavior, but works according to the default logic).

https://github.com/user-attachments/assets/2090b005-a8d2-4297-80e1-d3ef88997ba5

