### PR TITLE
Fixed the "back to main menu" button in the ship selection menu.

### DIFF
--- a/Battleship/BattleshipGame.cs
+++ b/Battleship/BattleshipGame.cs
@@ -196,7 +196,7 @@ namespace Battleship
                             
                             _shipManager!.ReadClick = false;
                         }
-                        else if (shipSelectionMenu.back)
+                        else if (shipSelectionMenu.back && Mouse.GetState().LeftButton == ButtonState.Released)
                         {
                             currentGameState = GameState.MainMenu; //Transistions back to main menu
                             base.Initialize();


### PR DESCRIPTION
Simple change, just forces the back to main menu button to not progress until the left click is released.